### PR TITLE
Fixes errors in console when using beheading enchantments.

### DIFF
--- a/Enchantments+-/src/org/eps/pvppack/EnchantProcessor.java
+++ b/Enchantments+-/src/org/eps/pvppack/EnchantProcessor.java
@@ -169,7 +169,7 @@ public class EnchantProcessor implements Listener {
 			{
 				ItemStack head = getHead(e.getEntity());
 				if (head != null)
-					e.getEntity().getWorld().dropItemNaturally(e.getEntity().getLocation(), head);
+					e.getDrops().add(head);
 			}
 		}
 	}
@@ -193,7 +193,7 @@ public class EnchantProcessor implements Listener {
 				SkullMeta skull = (SkullMeta) head.getItemMeta();
 				skull.setOwningPlayer(e.getEntity());
 				head.setItemMeta(skull);
-				e.getEntity().getWorld().dropItemNaturally(e.getEntity().getLocation(), head);
+				e.getDrops().add(head);
 			}
 		}
 	}

--- a/Enchantments+-/src/org/eps/pvppack/EnchantProcessor.java
+++ b/Enchantments+-/src/org/eps/pvppack/EnchantProcessor.java
@@ -168,7 +168,8 @@ public class EnchantProcessor implements Listener {
 			if (getNext() <= chance)
 			{
 				ItemStack head = getHead(e.getEntity());
-				e.getEntity().getWorld().dropItemNaturally(e.getEntity().getLocation(), head);
+				if (head != null)
+					e.getEntity().getWorld().dropItemNaturally(e.getEntity().getLocation(), head);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes errors in console when using beheading enchantments and the killed mob is not a Skeleton, Wither Skeleton, Zombie, Creeper, or Dragon.
eg.
```
[11:22:04] [Server thread/ERROR]: Could not pass event EntityDeathEvent to EnchantmentsPlusMinus v1.3r-0
java.lang.IllegalArgumentException: Cannot drop a Null item.
	at org.apache.commons.lang.Validate.notNull(Validate.java:192) ~[server.jar:git-Paper-318]
	at org.bukkit.craftbukkit.v1_16_R3.CraftWorld.dropItem(CraftWorld.java:747) ~[server.jar:git-Paper-318]
	at org.bukkit.craftbukkit.v1_16_R3.CraftWorld.dropItemNaturally(CraftWorld.java:763) ~[server.jar:git-Paper-318]
	at org.eps.pvppack.EnchantProcessor.onKill(EnchantProcessor.java:170) ~[?:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor157.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[server.jar:git-Paper-318]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[server.jar:git-Paper-318]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[server.jar:git-Paper-318]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607) ~[server.jar:git-Paper-318]
	at org.bukkit.craftbukkit.v1_16_R3.event.CraftEventFactory.callEntityDeathEvent(CraftEventFactory.java:801) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.EntityLiving.d(EntityLiving.java:1490) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.EntityLiving.die(EntityLiving.java:1419) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.EntityLiving.damageEntity(EntityLiving.java:1261) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.EntityHuman.attack(EntityHuman.java:1087) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.EntityPlayer.attack(EntityPlayer.java:1832) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.PlayerConnection.a(PlayerConnection.java:2236) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.PacketPlayInUseEntity.a(PacketPlayInUseEntity.java:49) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.PacketPlayInUseEntity.a(PacketPlayInUseEntity.java:6) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:23) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.TickTask.run(SourceFile:18) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.MinecraftServer.bb(MinecraftServer.java:1133) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.MinecraftServer.executeNext(MinecraftServer.java:1126) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.MinecraftServer.sleepForTick(MinecraftServer.java:1087) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1001) ~[server.jar:git-Paper-318]
	at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:178) ~[server.jar:git-Paper-318]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275]
```