### PR TITLE
File NPE Fix

### DIFF
--- a/EnchantmentsPlusMinus/src/org/vivi/eps/EPS.java
+++ b/EnchantmentsPlusMinus/src/org/vivi/eps/EPS.java
@@ -523,8 +523,7 @@ public class EPS extends JavaPlugin implements Reloadable {
 	 */
 	public static File getUserDataFile(UUID uuid)
 	{
-		if (uuid == null)
-			return null;
+		if (uuid == null) {return null;}
 		File dataFile = new File(dataFolder, uuid.toString()+".yml");
 		return dataFile;
 	}

--- a/EnchantmentsPlusMinus/src/org/vivi/eps/EPS.java
+++ b/EnchantmentsPlusMinus/src/org/vivi/eps/EPS.java
@@ -490,10 +490,9 @@ public class EPS extends JavaPlugin implements Reloadable {
 	 */
 	public static UUID getUUID(String username)
 	{
-		String stringUUID = uuidDataStoreData.getString(username);
-		if (stringUUID == null)
-			return null;
-		return UUID.fromString(stringUUID);
+		OfflinePlayer player = Bukkit.getOfflinePlayer(string);
+		if (!player.hasPlayedBefore()) {return null;}
+		return player.getUniqueId();
 	}
 
 	/** Gets the data file of the specified player.


### PR DESCRIPTION
This pull request is a fix for https://github.com/dsdd/EnchantmentsPlusMinus/issues/51

First of all, changed the getUuid to make more sense and not be dependent on some sort of wierd uuid store, and sticks to the Bukkit API. Also restructured the getUserDataFile function to use brackets, as that makes the code make a lot more sense and just generally follow standards and not feel like it will always return null. All functionality of whatever was there before was restored, including returning null if the player hasnt logged on before.